### PR TITLE
fix: only process select shortcode params to array

### DIFF
--- a/.test-site/content/tests/page/index.md
+++ b/.test-site/content/tests/page/index.md
@@ -99,7 +99,7 @@ testImages:
     alt: figure
     figcaption_title: Figure Title
     figcaption_title_h: 3
-    caption: Figure Caption
+    caption: Figure Caption, including comma
     attr: Attribution Text
     attr_link: http://www.author.com
     link: /

--- a/.test-site/layouts/_default/list.html
+++ b/.test-site/layouts/_default/list.html
@@ -20,7 +20,7 @@
 
       {{ range $pages }}
           <li>
-              <a href="{{.Permalink}}">{{.Date.Format "2006-01-02"}} | {{.Title}}</a>
+              <a href="{{.RelPermalink}}">{{.Date.Format "2006-01-02"}} | {{.Title}}</a>
           </li>
       {{ end }}
       </ul>

--- a/layouts/partials/hri/private/utils/process-shortcode-params.html
+++ b/layouts/partials/hri/private/utils/process-shortcode-params.html
@@ -23,8 +23,12 @@
 {{/* convert any comma delimited string-arrays to arrays */}}
 {{ $arrays := dict}}
 {{ range $key, $elem := . }}
-  {{/* work on the elem and reassign */}}
-  {{ $elem = partial "hri/private/utils/string-to-array" $elem }}
+  {{/* only convert comma delim string to array if one of the following keys */}}
+  {{ $toProcess := slice "widths" "aspect_ratio" "fill_ratio" "densities" "formats"}}
+  {{ if in $toProcess $key }}
+    {{/* work on the elem and reassign */}}
+    {{ $elem = partial "hri/private/utils/string-to-array" $elem }}
+  {{ end }}
   {{/* create a new, identical dict as the original context */}}
   {{ $arrays = merge $arrays (dict $key $elem) }}
 {{ end }}


### PR DESCRIPTION
shortcode param with , throws error as its converted to an array regardless of the key. now only select params are converted to arrays if a , is present