### PR TITLE
Fix new hugo int as int64 issue and remove usage of relref

### DIFF
--- a/.test-site/content/tests/page/index.md
+++ b/.test-site/content/tests/page/index.md
@@ -121,6 +121,27 @@ testImages:
       class: [figure]
     figcaption:
       class: [figure-caption]
+- id: js-test7a
+  title: 7a. figure external link
+  subtitle: 
+  partial: figure
+  params:
+    src: test7.jpg
+    alt: figure
+    figcaption_title: Figure Title
+    figcaption_title_h: 3
+    caption: Figure Caption, including comma
+    attr: Attribution Text
+    attr_link: http://www.author.com
+    link: http://www.google.com
+  tests:
+    img:
+      dataSizes: auto
+      class: ['figure-img', 'img-fluid', 'lazyloaded']
+    figure:
+      class: [figure]
+    figcaption:
+      class: [figure-caption]
 - id: js-test8
   title: 8. Image metadata
   subtitle: title and alt set in markup metadata

--- a/layouts/partials/hri/private/params/figure.html
+++ b/layouts/partials/hri/private/params/figure.html
@@ -33,10 +33,6 @@
       "ctx" $.error_ctx
     ) }}
   {{ else }}
-    {{ if hasPrefix $attr_link "http" }}
-      {{ $external_attr_link = true }}
-      {{ $attr_link = relref $ctx $attr_link }}
-    {{ end }}
     {{ $s.SetInMap "params" "attr_link" $attr_link }}
   {{ end }}
 {{ end }}
@@ -98,10 +94,6 @@
       "ctx" $.error_ctx
     ) }}
   {{ else }}
-    {{ if hasPrefix $link "http" }}
-      {{ $external_link = true }}
-      {{ $link = relref $.ctx $link }}
-    {{ end }}
     {{ $s.SetInMap "params" "link" $link }}
   {{ end }}
 {{ end }}

--- a/layouts/partials/hri/private/params/image-general.html
+++ b/layouts/partials/hri/private/params/image-general.html
@@ -306,7 +306,7 @@
 {{ with .render_hook.widths | default .shortcode.widths | default .widths | default $meta.widths | default ($ctx.Param "image.widths") }}
   {{ if reflect.IsSlice . }}
     {{ range . }}
-      {{ if ne (printf "%T" .) "int" }}
+      {{ if and (ne (printf "%T" .) "int") (ne (printf "%T" .) "int64") }}
         {{ partial "hri/private/utils/options-error" (dict 
           "var" "width in widths slice"
           "val" .


### PR DESCRIPTION
Fix the first issue of [#67](https://github.com/future-wd/hugo-responsive-images/issues/67#issuecomment-2191593986).

This might related to the latest version of go which the default int type is now `int64`.