### PR TITLE
Fix int type checks

### DIFF
--- a/layouts/partials/hri/private/params/figure.html
+++ b/layouts/partials/hri/private/params/figure.html
@@ -172,7 +172,7 @@
 {{ end }}
 
 {{ with .figcaption_title_h | default .figureTitleH |  default $meta.figcaption_title_h | default $meta.figureTitleH | default ($ctx.Param "image.figureTitleH") | default ($ctx.Param "image.figcaption_title_h") }}
-  {{ if not (eq (printf "%T" .) "int") }}
+  {{ if not (in (slice "int" "int64" "uint64") (printf "%T" .)) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "figcaption_title_h"
       "val" .

--- a/layouts/partials/hri/private/params/image-general.html
+++ b/layouts/partials/hri/private/params/image-general.html
@@ -26,7 +26,7 @@
 {{ with .densities | default $meta.densities | default ($ctx.Param "image.densities") }}
   {{ if reflect.IsSlice . }}
     {{ range . }}
-      {{ if ne (printf "%T" .) "int" }}
+      {{ if not (in (slice "int" "int64" "uint64") (printf "%T" .)) }}
         {{ partial "hri/private/utils/options-error" (dict 
         "var" "densities slice item"
         "val" .
@@ -306,7 +306,7 @@
 {{ with .render_hook.widths | default .shortcode.widths | default .widths | default $meta.widths | default ($ctx.Param "image.widths") }}
   {{ if reflect.IsSlice . }}
     {{ range . }}
-      {{ if and (ne (printf "%T" .) "int") (ne (printf "%T" .) "int64") }}
+      {{ if not (in (slice "int" "int64" "uint64") (printf "%T" .)) }}
         {{ partial "hri/private/utils/options-error" (dict 
           "var" "width in widths slice"
           "val" .

--- a/layouts/partials/hri/private/params/render-hook-general.html
+++ b/layouts/partials/hri/private/params/render-hook-general.html
@@ -40,7 +40,7 @@
 {{ with $meta.render_hook_widths | default $meta.renderHookWidths | default $meta.shortcode_widths | default $meta.shortcodeWidths | default $meta.widths | default $widths_page }}
   {{ if reflect.IsSlice . }}
     {{ range . }}
-      {{ if ne (printf "%T" .) "int" }}
+      {{ if not (in (slice "int" "int64" "uint64") (printf "%T" .)) }}
         {{ partial "hri/private/utils/options-error" (dict 
           "var" "width in widths slice"
           "val" .

--- a/layouts/partials/hri/private/params/shortcode-general.html
+++ b/layouts/partials/hri/private/params/shortcode-general.html
@@ -47,7 +47,7 @@
 {{ with .widths | default $widths_meta  }}
   {{ if reflect.IsSlice . }}
     {{ range . }}
-      {{ if ne (printf "%T" .) "int" }}
+      {{ if not (in (slice "int" "int64" "uint64") (printf "%T" .)) }}
         {{ partial "hri/private/utils/options-error" (dict 
           "var" "width in widths slice"
           "val" .


### PR DESCRIPTION
I recently upgraded from Hugo v0.112 to v0.152 and had a similar bug as #68 except I observed it at more places and the type was not `int64` but `uint64`. 

I updated those type checks wherever it was needed for my site to build, but there are other (see `grep -R "\"int\""`) which I didn't fix (yet), because I didn't encounter any problem with those checks.