### PR TITLE
Fix image parameters not being taken into account

### DIFF
--- a/layouts/_partials/hri/private/gen/external-widths.html
+++ b/layouts/_partials/hri/private/gen/external-widths.html
@@ -56,11 +56,11 @@
       {{/* resulting fillHeight must be converted to integer for use with image resize */}}
       {{ $fillHeight := mul $width.width . | int }}
       {{/* resize image */}}
-      {{ $imgResized = printf "%s?nfresize=smartcrop?w=%dh=%d" $.common.img.RelPermalink $width.width $fillHeight }}
+      {{ $imgResized = printf "%s?nfresize=smartcrop&w=%d&h=%d" $.common.img.RelPermalink $width.width $fillHeight }}
     {{ else }}
       {{/* do standard image resize */}}
       {{/* create resize path */}}
-      {{ $imgResized = printf "%s?nfresize=fit?w=%d" $.common.img.RelPermalink $width.width }}
+      {{ $imgResized = printf "%s?nfresize=fit&w=%d" $.common.img.RelPermalink $width.width }}
     {{ end }}
     {{/* add image to srcset array with format "/path/image.jpg 100w" or "/path/image.jpg 1x"  */}}
     {{ $srcset = $srcset | append (printf "%s %s" $imgResized $width.desc) }}
@@ -71,7 +71,7 @@
       {{ end }}
     {{ else }}
       {{/* else largest width (last iteration), add image to src variable for use as fallback */}}
-      {{ if eq (len $.widths) (add $index 1) }}
+      {{ if eq (len $.image.widths) (add $index 1) }}
         {{ $src = $imgResized }}
       {{ end }}
     {{ end }}

--- a/layouts/_partials/hri/private/params/image-placeholder.html
+++ b/layouts/_partials/hri/private/params/image-placeholder.html
@@ -23,7 +23,7 @@
 {{ end }}
 
 {{ with  .lqip_blur_amount | default .lqipBlurAmount | default $meta.lqip_blur_amount | default $meta.lqipBlurAmount | default ($ctx.Param "image.lqipBlurAmount") | default ($ctx.Param "image.lqip_blur_amount") }}
-  {{ if not (or (eq (printf "%T" .) "int") (eq (printf "%T" .) "float") ) }}
+  {{ if not (or (in (slice "int" "int64") (printf "%T" .)) (eq (printf "%T" .) "float64")) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "lqip_blur_amount"
       "val" .
@@ -36,7 +36,7 @@
 {{ end }}
 
 {{ with .gif_div_factor | default .gifDivFactor | default $meta.gif_div_factor | default $meta.gifDivFactor | default ($ctx.Param "image.gifDivFactor") | default ($ctx.Param "image.gif_div_factor") }}
-  {{ if not (or (eq (printf "%T" .) "int") (eq (printf "%T" .) "float") ) }}
+  {{ if not (or (in (slice "int" "int64") (printf "%T" .)) (eq (printf "%T" .) "float64")) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "gif_div_factor"
       "val" .
@@ -49,7 +49,7 @@
 {{ end }}
 
 {{ with .lqip_div_factor | default .lqipDivFactor | default $meta.lqip_div_factor | default $meta.lqipDivFactor | default ($ctx.Param "image.lqip_div_factor") | default ($ctx.Param "image.lqipDivFactor") }}
-  {{ if not (or (eq (printf "%T" .) "int") (eq (printf "%T" .) "float") ) }}
+  {{ if not (or (in (slice "int" "int64") (printf "%T" .)) (eq (printf "%T" .) "float64")) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "gif_div_factor"
       "val" .

--- a/layouts/_partials/hri/private/params/image-placeholder.html
+++ b/layouts/_partials/hri/private/params/image-placeholder.html
@@ -23,7 +23,7 @@
 {{ end }}
 
 {{ with  .lqip_blur_amount | default .lqipBlurAmount | default $meta.lqip_blur_amount | default $meta.lqipBlurAmount | default ($ctx.Param "image.lqipBlurAmount") | default ($ctx.Param "image.lqip_blur_amount") }}
-  {{ if not (or (in (slice "int" "int64") (printf "%T" .)) (eq (printf "%T" .) "float64")) }}
+  {{ if not (in (slice "int" "int8" "int16" "int32" "int64" "uint" "uint8" "uint16" "uint32" "uint64" "float32" "float64") (printf "%T" .)) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "lqip_blur_amount"
       "val" .
@@ -36,7 +36,7 @@
 {{ end }}
 
 {{ with .gif_div_factor | default .gifDivFactor | default $meta.gif_div_factor | default $meta.gifDivFactor | default ($ctx.Param "image.gifDivFactor") | default ($ctx.Param "image.gif_div_factor") }}
-  {{ if not (or (in (slice "int" "int64") (printf "%T" .)) (eq (printf "%T" .) "float64")) }}
+  {{ if not (in (slice "int" "int8" "int16" "int32" "int64" "uint" "uint8" "uint16" "uint32" "uint64" "float32" "float64") (printf "%T" .)) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "gif_div_factor"
       "val" .
@@ -49,7 +49,7 @@
 {{ end }}
 
 {{ with .lqip_div_factor | default .lqipDivFactor | default $meta.lqip_div_factor | default $meta.lqipDivFactor | default ($ctx.Param "image.lqip_div_factor") | default ($ctx.Param "image.lqipDivFactor") }}
-  {{ if not (or (in (slice "int" "int64") (printf "%T" .)) (eq (printf "%T" .) "float64")) }}
+  {{ if not (in (slice "int" "int8" "int16" "int32" "int64" "uint" "uint8" "uint16" "uint32" "uint64" "float32" "float64") (printf "%T" .)) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "gif_div_factor"
       "val" .

--- a/layouts/_partials/hri/private/params/image-placeholder.html
+++ b/layouts/_partials/hri/private/params/image-placeholder.html
@@ -15,7 +15,7 @@
       "var" "placeholder"
       "val" .
       "opts" "lqip, dominant or a color which matches a gif file"
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "placeholder" . }}
@@ -28,7 +28,7 @@
       "var" "lqip_blur_amount"
       "val" .
       "opts" "an integer or float blur amount"
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "lqip_blur_amount" . }}
@@ -41,7 +41,7 @@
       "var" "gif_div_factor"
       "val" .
       "opts" "an integer or float division factor"
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "gif_div_factor" . }}
@@ -54,7 +54,7 @@
       "var" "gif_div_factor"
       "val" .
       "opts" "an integer or float division factor"
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "lqip_div_factor" . }}

--- a/layouts/_partials/hri/private/params/image-placeholder.html
+++ b/layouts/_partials/hri/private/params/image-placeholder.html
@@ -48,7 +48,7 @@
   {{ end }}
 {{ end }}
 
-{{ with .lqip_div_factor | default .lqipDivFactor | default $meta.lqip_div_factor | default $meta.lqipDivFactor | default ($ctx.Param "image.lqip_div_factor") | default ($ctx.Param "image.lqip_div_factor") }}
+{{ with .lqip_div_factor | default .lqipDivFactor | default $meta.lqip_div_factor | default $meta.lqipDivFactor | default ($ctx.Param "image.lqip_div_factor") | default ($ctx.Param "image.lqipDivFactor") }}
   {{ if not (or (eq (printf "%T" .) "int") (eq (printf "%T" .) "float") ) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "gif_div_factor"

--- a/layouts/_partials/hri/private/params/image-processing.html
+++ b/layouts/_partials/hri/private/params/image-processing.html
@@ -39,7 +39,7 @@
       "var" "quality"
       "val" .
       "opts" "integers between 1-100 inclusive"
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "quality" (printf "q%v" . )}}
@@ -52,7 +52,7 @@
       "var" "rotate"
       "val" .
       "opts" "integers between 1-360 inclusive"
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "rotate" (printf "r%v" . ) }}
@@ -67,7 +67,7 @@
       "var" "resample_filter"
       "val" .
       "opts" (delimit $filter_opts ", ")
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "resample_filter" . }}
@@ -81,7 +81,7 @@
       "var" "hint"
       "val" .
       "opts" (delimit $hint_opts ", ")
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "hint" . }}
@@ -95,7 +95,7 @@
       "var" "anchor"
       "val" .
       "opts" (delimit $anchor_opts ", ")
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "anchor" . }}
@@ -109,7 +109,7 @@
       "var" "background_color"
       "val" .
       "opts" "3 or 6 digit hex color code"
-      "ctx" $.error_ctx
+      "ctx" $.common.error_ctx
     ) }}
   {{ else }}
     {{ $s.SetInMap "params" "background_color" . }}

--- a/layouts/_partials/hri/private/params/image-processing.html
+++ b/layouts/_partials/hri/private/params/image-processing.html
@@ -34,28 +34,30 @@
 {{ $ctx := .common.ctx }}
 
 {{ with .quality | default $meta.quality | default ($ctx.Param "image.quality") }}
-  {{ if not (and (in (slice "int" "int64") (printf "%T" .)) (and (ge . 1) (le . 100))) }}
-    {{ partial "hri/private/utils/options-error" (dict 
+  {{ $q := int . }}
+  {{ if not (and (ge $q 1) (le $q 100)) }}
+    {{ partial "hri/private/utils/options-error" (dict
       "var" "quality"
       "val" .
       "opts" "integers between 1-100 inclusive"
       "ctx" $.common.error_ctx
     ) }}
   {{ else }}
-    {{ $s.SetInMap "params" "quality" (printf "q%v" . )}}
+    {{ $s.SetInMap "params" "quality" (printf "q%v" $q) }}
   {{ end }}
 {{ end }}
 
 {{ with .rotate | default $meta.rotate | default ($ctx.Param "image.rotate") }}
-  {{ if not (and (in (slice "int" "int64") (printf "%T" .)) (and (ge . 1) (le . 360))) }}
-    {{ partial "hri/private/utils/options-error" (dict 
+  {{ $r := int . }}
+  {{ if not (and (ge $r 1) (le $r 360)) }}
+    {{ partial "hri/private/utils/options-error" (dict
       "var" "rotate"
       "val" .
       "opts" "integers between 1-360 inclusive"
       "ctx" $.common.error_ctx
     ) }}
   {{ else }}
-    {{ $s.SetInMap "params" "rotate" (printf "r%v" . ) }}
+    {{ $s.SetInMap "params" "rotate" (printf "r%v" $r) }}
   {{ end }}
 {{ end }}
 

--- a/layouts/_partials/hri/private/params/image-processing.html
+++ b/layouts/_partials/hri/private/params/image-processing.html
@@ -34,7 +34,7 @@
 {{ $ctx := .common.ctx }}
 
 {{ with .quality | default $meta.quality | default ($ctx.Param "image.quality") }}
-  {{ if not (and (eq (printf "%T" .) "int") (and (ge . 1) (le . 100))) }}
+  {{ if not (and (in (slice "int" "int64") (printf "%T" .)) (and (ge . 1) (le . 100))) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "quality"
       "val" .
@@ -47,7 +47,7 @@
 {{ end }}
 
 {{ with .rotate | default $meta.rotate | default ($ctx.Param "image.rotate") }}
-  {{ if not (and (eq (printf "%T" .) "int") (and (ge . 1) (le . 360))) }}
+  {{ if not (and (in (slice "int" "int64") (printf "%T" .)) (and (ge . 1) (le . 360))) }}
     {{ partial "hri/private/utils/options-error" (dict 
       "var" "rotate"
       "val" .

--- a/layouts/_partials/hri/private/params/image.html
+++ b/layouts/_partials/hri/private/params/image.html
@@ -29,12 +29,12 @@
 {{ $params := partial "hri/private/params/image-general" . }}
 
 {{ if not $params.provider }}
-  {{ $processing_params := partial "hri/private/params/image-processing" $params }}
+  {{ $processing_params := partial "hri/private/params/image-processing" . }}
   {{ $params = merge $params (dict "options" $processing_params) }}
 {{ end }}
 
 
-{{ $placeholder_params := partial "hri/private/params/image-placeholder" $params }}
+{{ $placeholder_params := partial "hri/private/params/image-placeholder" . }}
 {{ $params = merge $params $placeholder_params }}
 
 

--- a/layouts/_partials/hri/private/print/picture-set.html
+++ b/layouts/_partials/hri/private/print/picture-set.html
@@ -25,6 +25,9 @@
   {{- else }}
     type="{{ printf "image/%s" .format }}"
   {{- end }}
+  {{- with $.image.sizes_prop }}
+    {{ . | safeHTMLAttr }}
+  {{- end }}
   />
 {{- end }}
 {{- partial "hri/private/print/image-tag" . -}}


### PR DESCRIPTION
This fixes an issue where various image parameters like `quality`, `hint` or `resample_filter` where not taken into account, for example for images defined at the page level:

```yaml
resources:
- src: foo.png
  params:
    image:
      formats: ["png", "webp"]
      resample_filter: "MitchellNetravali"
      quality: 90
      hint: "picture"
```

All parameters are now taken into account, regenerating images on the fly and outputting errors when there are issues with the parameters.

This also fixes other bugs:
* Mixup between `&` and `%` for the Netlify resize URL
* Images sizes attribute missing from the `<source>` elements